### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,6 +19,16 @@ class ItemsController < ApplicationController
     end
   end
 
+
+  def show
+    @item = Item.find(params[:id])
+  end
+
+
+
+
+
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,15 +19,9 @@ class ItemsController < ApplicationController
     end
   end
 
-
   def show
     @item = Item.find(params[:id])
   end
-
-
-
-
-
 
   private
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -132,7 +132,7 @@
         <% unless @items.length == 0 %>
           <%# @itemの中が空ではない場合は %>
           <li class='list'>
-            <%= link_to "#" do %>
+            <%= link_to item_path(item.id), method: :get do %>
               <div class='item-img-content'>
                 <% if item.image.attached? %>
                   <%= image_tag item.image, class: "item-img" %>
@@ -192,7 +192,9 @@
   <%# /商品一覧 %>
 </div>
 <div class='purchase-btn'>
-    <span class='purchase-btn-text'><%= link_to '出品する', new_item_path %></span>
+    <span class='purchase-btn-text'>出品する</span>
+    <%= link_to new_item_path do %>
       <%= image_tag 'camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
+    <% end %>
 </div>
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,83 +1,86 @@
 <%= render "shared/header" %>
 
 <%# 商品の概要 %>
-<div class="item-show">
-  <div class="item-box">
-    <h2 class="name">
-      <%= "商品名" %>
-    </h2>
-    <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class='sold-out'>
-        <span>Sold Out!!</span>
+  <div class="item-show">
+    <div class="item-box">
+      <h2 class="name">
+        <%= @item.name %>
+      </h2>
+      <div class='item-img-content'>
+      <% if @item.image.attached? %>
+        <%= image_tag @item.image ,class:"item-box-img" %>
+      <% end %>
+        <%# 商品が売れている場合は、sold outを表示しましょう %>
+        <div class='sold-out'>
+          <span>Sold Out!!</span>
+        </div>
+        <%# //商品が売れている場合は、sold outを表示しましょう %>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
-    </div>
-    <div class="item-price-box">
-      <span class="item-price">
-        ¥ 999,999,999
-      </span>
-      <span class="item-postage">
-        (税込) 送料込み
-      </span>
-    </div>
-
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
-    </div>
-    <table class="detail-table">
-      <tbody>
-        <tr>
-          <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
-        </tr>
-      </tbody>
-    </table>
-    <div class="option">
-      <div class="favorite-btn">
-        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
-        <span>お気に入り 0</span>
+      <div class="item-price-box">
+        <span class="item-price">
+          ¥<%= @item.price %>
+        </span>
+        <span class="item-postage">
+          <%= @item.delivery_fee.name %> 
+        </span>
       </div>
-      <div class="report-btn">
-        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
-        <span>不適切な商品の通報</span>
+
+      <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+      <% if user_signed_in? && current_user.id == @item.user.id %>
+        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <p class='or-text'>or</p>
+        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <% elsif user_signed_in? && current_user.id != @item.user.id %>
+        <%# 商品が売れていない場合はこちらを表示しましょう %>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+        <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <% end %>
+
+      <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+
+      <div class="item-explain-box">
+        <span><%= @item.explanation %></span>
+      </div>
+      <table class="detail-table">
+        <tbody>
+          <tr>
+            <th class="detail-item">出品者</th>
+            <td class="detail-value"><%= @item.user.nickname%></td>
+          </tr>
+          <tr>
+            <th class="detail-item">カテゴリー</th>
+            <td class="detail-value"><%= @item.category.name %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">商品の状態</th>
+            <td class="detail-value"><%= @item.status.name %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">配送料の負担</th>
+            <td class="detail-value"><%= @item.delivery_fee.name %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">発送元の地域</th>
+            <td class="detail-value"><%= @item.delivery_from.name %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">発送日の目安</th>
+            <td class="detail-value"><%= @item.delivery_day.name %></td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="option">
+        <div class="favorite-btn">
+          <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+          <span>お気に入り 0</span>
+        </div>
+        <div class="report-btn">
+          <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+          <span>不適切な商品の通報</span>
+        </div>
       </div>
     </div>
-  </div>
+ 
   <%# /商品の概要 %>
 
   <div class="comment-box">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   } 
 
     
-    resources :items, only: [:new, :create]
+    resources :items, only: [:new, :create, :show]
   
 
 


### PR DESCRIPTION
#WHAT
商品詳細表示機能の実装

#WHY
商品詳細表示機能の実装：商品の詳細情報を確認および、出品者は編集ページ遷移や削除、出品者以外のログインしているユーザーは購入画面に遷移できるようにするため

#その他
Rubocop実行済

商品詳細表示動画（出品者）
https://gyazo.com/a705175d10016dc15daca0d7fd2fb356
商品詳細表示動画（出品者以外のログイン済ユーザー）
https://gyazo.com/6dc1f3ee5ea42dc6fb6895e4c9fb6fe4
商品詳細表示動画（出品者以外のログインしていないユーザー）
https://gyazo.com/d725dd1ad92d3b9450be5af66e3d6c81
